### PR TITLE
Add PyTorch submodule

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿# mlcrate
+# mlcrate
 [![PyPI version](https://badge.fury.io/py/mlcrate.svg)](https://pypi.python.org/pypi/mlcrate/)  
 A collection of handy python tools and helper functions, mainly for machine learning-related packages and Kaggle.
 
@@ -26,6 +26,16 @@ Saving `.feather` files additionally requires `feather-format`
 If you find any bugs or have any feature suggestions (even general feature requests unrelated to what's already in the package), feel free to open an issue. Pull requests are also very welcome :slightly_smiling_face:
 
 # Docs
+
+- Main module
+    + [Save/Load](#saveload)
+    + [Writing to a csv log one line at a time](#writing-to-a-csv-log-one-line-at-a-time)
+    + [Easy multi-threaded function mapping with realtime progress bars](#easy-multi-threaded-function-mapping-with-realtime-progress-bars)
+- [Time](#time)
+- [Kaggle](#kaggle)
+- [XGBoost](#xgboost)
+- [PyTorch](#pytorch)
+    + [Painless conversion between Python/NumPy types and PyTorch tensors](#painless-conversion-between-pythonnumpy-types-and-pytorch-tensors)
 
 ### Save/Load
 
@@ -225,6 +235,7 @@ Optionally, the split can be stratified along a passed array. Feature importance
 
 ```python
 >>> from mlcrate.torch import totensor, tonp
+
 >>> tensor = totensor([1, 2, 3]) # Convert almost any iterable or scalar to a PyTorch tensor easily
 >>> tensor
 tensor([ 1.,  2.,  3.])
@@ -238,10 +249,10 @@ tensor(1.)
 1.
 ```
 
-###### mlcrate.torch.tonp(tensor)
+###### [mlcrate.torch.tonp(tensor)](https://github.com/mxbi/mlcrate/blob/torch/mlcrate/torch.py#L13)
 Takes any PyTorch tensor and converts it to a numpy array or scalar as appropiate. Not heavily optimized.
 
-###### mlcrate.torch.totensor(arr, device=None, type='float32')
+###### [mlcrate.torch.totensor(arr, device=None, type='float32')](https://github.com/mxbi/mlcrate/blob/torch/mlcrate/torch.py#L22)
 
 Converts any array-like or scalar to a PyTorch tensor, and checks that the array is in the correct type (defaults to float32) and on the correct device.  
 Equivalent to calling `torch.from_array(np.array(arr, dtype=type)).to(device)` but more efficient.  

--- a/README.md
+++ b/README.md
@@ -1,21 +1,24 @@
 ﻿# mlcrate
 [![PyPI version](https://badge.fury.io/py/mlcrate.svg)](https://pypi.python.org/pypi/mlcrate/)  
-A collection of handy python tools and functions, mainly for ML and Kaggle.
+A collection of handy python tools and helper functions, mainly for machine learning-related packages and Kaggle.
 
-The methods in this package aren't revolutionary, and most of them are very simple. They are largely bunch of 'macro' functions which I often end up rewriting across multiple projects, all in one place and easily accessible as a quality of life improvement. Hopefully, they can be some use to others in the community too.
+The methods in this package aren't revolutionary, and most of them are very simple. They are largely bunch of 'macro' functions which I often end up rewriting across multiple projects, and various helper functions for different packages, all in one place and easily accessible as a quality of life improvement. Hopefully, they can be some use to others in the community too.
 
-This package has been tested with Python 3.5+, but should work with all versions of Python 3. Python 2 is not officially supported (although most of the functions would work in theory.)
+This package has been tested with Python 3.5+, but should work with all versions of Python 3. Python 2 is not officially supported.
 
 ### Installation
 
 `pip install mlcrate`
 
-Alternatively, clone the repo and run `python setup.py install` within the top-level folder to install the bleeding-edge version.
+Alternatively, clone the repo and run `python setup.py install` within the top-level folder to install the bleeding-edge version - this is recommended.
 
 ### Dependencies
 
 Required dependencies: `numpy`, `pandas`, `pathos`, `tqdm`  
+
 `mlcrate.xgb` additionally requires: `scikit-learn`, `xgboost`  
+`mlcrate.torch` additionally requires: `pytorch`
+
 Saving `.feather` files additionally requires `feather-format`
 
 ### Contributing
@@ -215,3 +218,39 @@ Optionally, the split can be stratified along a passed array. Feature importance
 `p_train` -- Out-of-fold training set predictions (shaped like y_train)  
 `p_test` -- Mean of test set predictions from the models  
 `imps` -- dict with \{feature: importance\} pairs representing the sum feature importance from all the models.
+
+### PyTorch
+
+#### Painless conversion between Python/NumPy types and PyTorch tensors
+
+```python
+>>> from mlcrate.torch import totensor, tonp
+>>> tensor = totensor([1, 2, 3]) # Convert almost any iterable or scalar to a PyTorch tensor easily
+>>> tensor
+tensor([ 1.,  2.,  3.])
+>>> tonp(tensor) # Convert any PyTorch tensor back into a numpy array! No more tensor.data.detach().cpu().numpy()
+array([1., 2., 3.], dtype=float32)
+
+>>> tensor = totensor(1, 'cpu') # Device can be specified too!
+>>> tensor
+tensor(1.)
+>>> tonp(tensor) # Also works with scalars
+1.
+```
+
+###### mlcrate.torch.tonp(tensor)
+Takes any PyTorch tensor and converts it to a numpy array or scalar as appropiate. Not heavily optimized.
+
+###### mlcrate.torch.totensor(arr, device=None, type='float32')
+
+Converts any array-like or scalar to a PyTorch tensor, and checks that the array is in the correct type (defaults to float32) and on the correct device.  
+Equivalent to calling `torch.from_array(np.array(arr, dtype=type)).to(device)` but more efficient.  
+NOTE: If the input is a torch tensor, the type will not be checked.
+
+Keyword arguments:  
+`arr` -- Any array-like object (eg numpy array, list, numpy varaible)  
+`device` (optional) -- Move the tensor to this device after creation  
+`type` -- the numpy data type of the tensor. Defaults to 'float32' (regardless of the input)  
+
+*Returns:*  
+`tensor` - A torch tensor

--- a/mlcrate/torch.py
+++ b/mlcrate/torch.py
@@ -53,7 +53,7 @@ def totensor(arr, device=None, type='float32'):
 
 # We define the class only at call-time to allow for lazy torch import
 # TODO: Find a less hacky way of doing this. If you have any ideas let me know :)
-def MLP(dim, dropout=0.3, hidden_activation=torch.nn.ReLU, output_activation=None):
+def MLP(dim, dropout=0.3, hidden_activation='relu', output_activation=None):
     """A fully connected MLP network with the specified sizes at each layer.
 
     Arguments:
@@ -64,6 +64,9 @@ def MLP(dim, dropout=0.3, hidden_activation=torch.nn.ReLU, output_activation=Non
     output_activation (optional) -- Activation function at the end of the network.
     """
     _check_torch_import()
+    
+    if hidden_activation == 'relu':
+        hidden_activation = torch.nn.ReLU
 
     class mlc_MLP(torch.nn.Module):
         def __init__(self, dim, dropout, hidden_activation, output_activation):

--- a/mlcrate/torch.py
+++ b/mlcrate/torch.py
@@ -22,14 +22,23 @@ def tonp(tensor):
 def totensor(arr, device=None, type='float32'):
     """Converts any array-like or scalar to a PyTorch tensor, and checks that the array is in the correct type (defaults to float32) and on the correct device.
     Equivalent to calling `torch.from_array(np.array(arr, dtype=type)).to(device)` but more efficient.
+    NOTE: If the input is a torch tensor, the type will not be checked.
 
     Keyword arguments:
     arr -- Any array-like object (eg numpy array, list, numpy varaible)
-    features -- a list of feature names corresponding to the features the model was trained on.
+    device (optional) -- Move the tensor to this device after creation
+    type -- the numpy data type of the tensor. Defaults to 'float32' (regardless of the input)
 
     Returns:
-    importance -- A list of (feature, importance) tuples representing sorted importance"""
+    tensor - A torch tensor"""
     _check_torch_import()
+    # If we're given a tensor, send it right back.
+    if isinstance(arr, torch.Tensor):
+        if device:
+            return arr.to(device) # If tensor is already on the specified device, this doesn't copy the tensor.
+        else:
+            return arr
+
     # Only call np.array() if it is not already an array, otherwise numpy will waste time copying the array
     if not isinstance(arr, np.ndarray):
         arr = np.array(arr)
@@ -41,3 +50,41 @@ def totensor(arr, device=None, type='float32'):
     if device:
         tensor = tensor.to(device)
     return tensor
+
+# We define the class only at call-time to allow for lazy torch import
+# TODO: Find a less hacky way of doing this. If you have any ideas let me know :)
+def MLP(dim, dropout=0.3, hidden_activation=torch.nn.ReLU, output_activation=None):
+    """A fully connected MLP network with the specified sizes at each layer.
+
+    Arguments:
+    shape -- A list of the shape of the network. The first item is the input size and the last item is the output size.
+             Eg. [128, 512, 512, 1] defines a network with 128 inputs, 1 output and two hidden layers of size 512.
+    dropout (default: 0.3) -- Proportion for dropout inbetween layers
+    hidden_activation (default: torch.nn.ReLU) -- Activation function between layers.
+    output_activation (optional) -- Activation function at the end of the network.
+    """
+    _check_torch_import()
+
+    class mlc_MLP(torch.nn.Module):
+        def __init__(self, dim, dropout, hidden_activation, output_activation):
+            super(self, mlc_MLP).__init__()
+
+            self.layers = []
+            for f_in, f_out in zip(dim[:-2], dim[1:-1]):
+                self.layers += [
+                    torch.nn.Linear(f_in, f_out),
+                    hidden_activation(),
+                    torch.nn.Dropout(dropout),
+                ]
+
+            self.layers += [torch.nn.Linear(dim[-2], dim[-1])]
+
+            if output_activation:
+                self.layers += [output_activation()]
+
+            self.model = torch.nn.Sequential(*self.layers)
+
+        def forward(self, x):
+            return self.model(x)
+
+    return mlc_MLP(dim, dropout, hidden_activation, output_activation)

--- a/mlcrate/torch.py
+++ b/mlcrate/torch.py
@@ -1,0 +1,43 @@
+import numpy as np
+
+# We lazy-load torch the first time one of the functions that requires it is called
+torch = None
+
+def _check_torch_import():
+    global torch
+    if torch is not None:
+        return
+    import importlib
+    torch = importlib.import_module('torch')
+
+def tonp(tensor):
+    """Takes any PyTorch tensor and converts it to a numpy array or scalar as appropiate.
+    Not heavily optimized."""
+    arr = tensor.data.detach().cpu().numpy()
+    if arr.shape == ():
+        return np.asscalar(arr)
+    else:
+        return arr
+
+def totensor(arr, device=None, type='float32'):
+    """Converts any array-like or scalar to a PyTorch tensor, and checks that the array is in the correct type (defaults to float32) and on the correct device.
+    Equivalent to calling `torch.from_array(np.array(arr, dtype=type)).to(device)` but more efficient.
+
+    Keyword arguments:
+    arr -- Any array-like object (eg numpy array, list, numpy varaible)
+    features -- a list of feature names corresponding to the features the model was trained on.
+
+    Returns:
+    importance -- A list of (feature, importance) tuples representing sorted importance"""
+    _check_torch_import()
+    # Only call np.array() if it is not already an array, otherwise numpy will waste time copying the array
+    if not isinstance(arr, np.ndarray):
+        arr = np.array(arr)
+    # Likewise with type conversion
+    if arr.dtype != type:
+        arr = arr.astype(type, copy=False)
+
+    tensor = torch.from_numpy(arr)
+    if device:
+        tensor = tensor.to(device)
+    return tensor


### PR DESCRIPTION
Adds an _optional_ PyTorch dependency (lazily-imported when functions from the submodule are used)

Features:
- `tonp()` and `totensor()` for frictionless conversion between Python/NumPy types and Torch tensors
- `MLP()`, an (experimental) constructor function for a simple adjustable MLP network
- More to come hopefully 🙂 